### PR TITLE
add release publish workflow

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -4,16 +4,18 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   pull_request:
     branches:
       - main
 
+env:
+  NODE_VER: 16.14.0
+
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    env:
-      NODE_VER: 16.14.0
 
     services:
       # docker run --name durabletask-sidecar -p 4001:4001 --env 'DURABLETASK_SIDECAR_LOGLEVEL=Debug' --rm cgillum/durabletask-sidecar:latest start --backend Emulator
@@ -43,3 +45,30 @@ jobs:
 
       - name: ✅ Run e2e tests
         run: ./scripts/test-e2e.sh
+
+  publish:
+    needs: build
+    if: startswith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    # TODO environment?
+    # environment: production
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v2
+
+      - name: ⚙️ NodeJS - Install
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VER }}
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build package
+        run: npm run build-ci
+
+      - name: Publish to npm (@dapr/dapr)
+        run: npm publish build/ --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Build package
         run: npm run build-ci
 
-      - name: Publish to npm (@dapr/dapr)
+      - name: Publish to npm (@dapr/durabletask-js)
         run: npm publish build/ --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@microsoft/durabletask-js",
+  "name": "@dapr/durabletask-js",
   "version": "0.1.0-alpha.2",
   "description": "A Durable Task Javascript SDK compatible with Dapr Workflow and its underlying Durable Task engine",
   "types": "./build/index.d.ts",
@@ -17,19 +17,20 @@
     "pretty": "prettier --list-different \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "pretty-fix": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "prebuild": "./scripts/prebuild.sh",
-    "build": "npm install && npm run lint && npm run pretty && ./scripts/build.sh"
+    "build": "npm install && npm run lint && npm run pretty && ./scripts/build.sh",
+    "build-ci": "npm run prebuild && ./scripts/build.sh"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/microsoft/durabletask-js.git"
+    "url": "git+https://github.com/dapr/durabletask-js.git"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/microsoft/durabletask-js/issues"
+    "url": "https://github.com/dapr/durabletask-js/issues"
   },
-  "homepage": "https://github.com/microsoft/durabletask-js#readme",
+  "homepage": "https://github.com/dapr/durabletask-js#readme",
   "devDependencies": {
     "@swc/core": "^1.3.55",
     "@swc/helpers": "^0.5.1",


### PR DESCRIPTION
updates the github workflow to publish to npm and updates the package name to be `@dapr/durabletask-js`