### PR TITLE
Added possible missing setting of the instance ID when an activity fails

### DIFF
--- a/src/worker/task-hub-grpc-worker.ts
+++ b/src/worker/task-hub-grpc-worker.ts
@@ -287,6 +287,7 @@ export class TaskHubGrpcWorker {
       const failureDetails = pbh.newFailureDetails(e);
 
       res = new pb.ActivityResponse();
+      res.setInstanceid(instanceId);
       res.setTaskid(req.getTaskid());
       res.setFailuredetails(failureDetails);
     }


### PR DESCRIPTION
Possible fix for https://github.com/dapr/js-sdk/issues/708